### PR TITLE
V1.3.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "Lua.diagnostics.globals": [
+        "SlashCmdList",
+        "Settings"
+    ]
+}

--- a/KamberQuests ChangeLog.txt
+++ b/KamberQuests ChangeLog.txt
@@ -1,3 +1,15 @@
+V1.3.0
+	removed the check for manually checked quests as something has changed in the Blizzard Quest API and the auto-tracked quests are being marked as manual too
+	Added "track all" to force all trackable quests to track. Will likely hit a limit for tracked quests so still won't see them all?
+	Added profession quest tracking
+	Added "important" quest tracking - not sure which quests are being flagged as important by Blizzard though
+	Added delves and scenarios to the dungeon tracking option.  (checking for dungeons checks all three quest types)
+	Added some additional zone and completion checks to try and capture it all
+	Added a sortation call after tracking quests - should use Blizzard's sortation for proximity to player
+	Added a options panel refresh if its open and the player uses a slash command to change a setting
+
+	(hoping that the manual vs auto tracking flag bug in the API gets fixed so I can allow for manually tracked quests again.)
+
 V1.2.8
 	converted to Settings. instead of InterfaceOptions_ for the settings/options panel
 	TOC update to 11.0

--- a/KamberQuests.toc
+++ b/KamberQuests.toc
@@ -2,7 +2,7 @@
 ## Title: KamberQuests
 ## Author: Radbarn
 ## Notes: Automated quest tracking based on daily/weekly/zones/completed
-## Version: KQ1.2.8
+## Version: KQ1.3.0
 ## SavedVariables: KamberQuestsDB
 ## X-Curse-Project-ID: 964781
 ## IconTexture: Interface\AddOns\KamberQuests\KamberQuests_Icon.tga

--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
 # KamberQuests
  WoW Addon - KamberQuests
 
-Automatically adds and removes quests from being tracked by the blizzard quest tracker based on:
-
-  all quests in your current zone,
-
-  all daily quests regardless of zone,
-
-  all weekly quests regardless of zone,
-
-  all raid quests regardless of zone,
-
-  all dungeon quests regardless of zone,
-
-  all pvp quests regardless of zone,
-
-  all completed quests regardless of zone.
+Automatically adds and removes quests from being tracked by the blizzard quest tracker based on location, completed, quest tags, etc.
 
 all of these options can be turned on or off independently.
 


### PR DESCRIPTION
V1.3.0
	removed the check for manually checked quests as something has changed in the Blizzard Quest API and the auto-tracked quests are being marked as manual too
	Added "track all" to force all trackable quests to track. Will likely hit a limit for tracked quests so still won't see them all?
	Added profession quest tracking
	Added "important" quest tracking - not sure which quests are being flagged as important by Blizzard though
	Added delves and scenarios to the dungeon tracking option.  (checking for dungeons checks all three quest types)
	Added some additional zone and completion checks to try and capture it all
	Added a sortation call after tracking quests - should use Blizzard's sortation for proximity to player
	Added a options panel refresh if its open and the player uses a slash command to change a setting
        Fixed categorization bugs with the above additions.

	(hoping that the manual vs auto tracking flag bug in the API gets fixed so I can allow for manually tracked quests again.)